### PR TITLE
Better history

### DIFF
--- a/img.php
+++ b/img.php
@@ -11,6 +11,7 @@ define('DOKU_DISABLE_GZIP_OUTPUT', 1);
 require_once(DOKU_INC . 'inc/init.php');
 session_write_close();
 
+/** @var helper_plugin_statistics $plugin */
 $plugin = plugin_load('helper', 'statistics');
 try {
     $plugin->Graph()->render($_REQUEST['img'], $_REQUEST['f'], $_REQUEST['t'], $_REQUEST['s']);

--- a/inc/StatisticsGraph.class.php
+++ b/inc/StatisticsGraph.class.php
@@ -128,7 +128,8 @@ class StatisticsGraph {
         $DataSet->AddAllSeries();
         $DataSet->SetAbscissaLabelSeries('Times');
 
-        $DataSet->SetSeriesName($this->hlp->getLang('graph_'.$info), 'Serie1');
+        $DataSet->setXAxisName($this->hlp->getLang($interval));
+        $DataSet->setYAxisName($this->hlp->getLang('graph_'.$info));
 
         $Canvas = new GDCanvas(600, 200, false);
         $Chart  = new pChart(600, 200, $Canvas);
@@ -143,11 +144,6 @@ class StatisticsGraph {
 
         $DataSet->removeSeries('Times');
         $DataSet->removeSeriesName('Times');
-        $Chart->drawLegend(
-            75, 5,
-            $DataSet->GetDataDescription(),
-            new Color(250)
-        );
 
 
         header('Content-Type: image/png');

--- a/inc/StatisticsGraph.class.php
+++ b/inc/StatisticsGraph.class.php
@@ -95,21 +95,33 @@ class StatisticsGraph {
     protected function history($info) {
         $diff = abs(strtotime($this->from) - strtotime($this->to));
         $days = floor($diff / (60*60*24));
-        $months = $days > 40;
+        if ($days > 365) {
+            $interval= 'months';
+        } elseif ($days > 56) {
+            $interval = 'weeks';
+        } else {
+            $interval = 'days';
+        }
 
-        $result = $this->hlp->Query()->history($this->tlimit, $info, $months);
+        $result = $this->hlp->Query()->history($this->tlimit, $info, $interval);
 
         $data = array();
         $times = array();
         foreach($result as $row) {
             $data[] = $row['cnt'];
-            if($months) {
-                $times[] = substr($row['time'],0,4).'-'.substr($row['time'],4,2);
+            if($interval == 'months') {
+                $times[] = substr($row['time'], 0, 4) . '-' . substr($row['time'], 4, 2);
+            } elseif ($interval == 'weeks') {
+                $times[] = $row['EXTRACT(YEAR FROM dt)'] . '-' . $row['time'];
             }else {
                 $times[] = substr($row['time'], -5);
             }
         }
 
+        // todo: change legend to y-axis label
+        // todo: add x-axis label
+        // todo: correctly scale y axis
+        // todo: column diagram?
         $DataSet = new pData();
         $DataSet->AddPoints($data, 'Serie1');
         $DataSet->AddPoints($times, 'Times');

--- a/inc/StatisticsGraph.class.php
+++ b/inc/StatisticsGraph.class.php
@@ -118,10 +118,6 @@ class StatisticsGraph {
             }
         }
 
-        // todo: change legend to y-axis label
-        // todo: add x-axis label
-        // todo: correctly scale y axis
-        // todo: column diagram?
         $DataSet = new pData();
         $DataSet->AddPoints($data, 'Serie1');
         $DataSet->AddPoints($times, 'Times');

--- a/inc/StatisticsQuery.class.php
+++ b/inc/StatisticsQuery.class.php
@@ -193,7 +193,7 @@ class StatisticsQuery {
         }
 
         $sql = "SELECT $TIME as time,
-                       SUM(`value`)/$mod as cnt
+                       AVG(`value`)/$mod as cnt
                   FROM " . $this->hlp->prefix . "history as A
                  WHERE $tlimit
                    AND info = '$info'

--- a/inc/StatisticsQuery.class.php
+++ b/inc/StatisticsQuery.class.php
@@ -178,8 +178,10 @@ class StatisticsQuery {
         return $data;
     }
 
-    public function history($tlimit, $info, $months = false) {
-        if($months) {
+    public function history($tlimit, $info, $interval = false) {
+        if($interval == 'weeks') {
+            $TIME = 'EXTRACT(YEAR FROM dt), EXTRACT(WEEK FROM dt)';
+        } elseif ($interval == 'months') {
             $TIME = 'EXTRACT(YEAR_MONTH FROM dt)';
         } else {
             $TIME = 'dt';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -2,22 +2,31 @@
 
 /**
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * 
+ *
  * @author Tim Weinhold <tim.weinhold@gmail.com>
  * @author Cornelius Kölbel <corny@cornelinux.de>
  * @author Thor Weinreich <thorweinreich@nefkom.net>
  * @author Andreas Gohr <gohr@cosmocode.de>
+ * @author Michael Große <grosse@cosmocode.de>
  */
 $lang['menu']                  = 'Zugriffs- und Verwendungsstatistik';
+
 $lang['more']                  = 'mehr';
 $lang['prev']                  = 'Vorherige Seite';
 $lang['next']                  = 'Nächste Seite';
+
+
 $lang['time_select']           = 'Zeitfenster auswählen:';
 $lang['time_today']            = 'Heute';
 $lang['time_last1']            = 'Gestern';
 $lang['time_last7']            = 'Letzte 7 Tage';
 $lang['time_last30']           = 'Letzte 30 Tage';
 $lang['time_go']               = 'Los';
+$lang['days']                  = 'Tage';
+$lang['weeks']                 = 'Wochen';
+$lang['months']                = 'Monate';
+
+
 $lang['dashboard']             = 'Dashboard';
 $lang['page']                  = 'Seiten';
 $lang['edits']                 = 'Bearbeitungen';
@@ -47,6 +56,10 @@ $lang['users']                 = '(Nutzer und Gruppen)';
 $lang['links']                 = '(Links)';
 $lang['search']                = '(Suche)';
 $lang['technology']            = '(Technologie)';
+
+
+
+
 $lang['intro_dashboard']       = 'Diese Seite gibt Ihnen einen Überblick über die Aktivitäten in Ihrem Wiki in dem gewählten Zeitraum.<br />Wenn Sie ein Thema aus dem Inhaltsverzeichnis wählen, bekommen Sie weitere Details und Graphen angezeigt.';
 $lang['intro_page']            = 'Dies sind die Wiki-Seiten, die in dem gewählten Zeitraum am häufigsten angezeigt wurden.';
 $lang['intro_edits']           = 'Dies sind die am meisten bearbeiteten Wiki-Seiten im ausgewählten Zeitraum. Hier passiert im Moment am meisten in Ihrem Wiki.';
@@ -72,6 +85,8 @@ $lang['intro_topuser']         = 'Diese Seite zeigt welche eingeloggten Nutzer d
 $lang['intro_topeditor']       = 'Diese Seite zeigt welche eingeloggten Nutzer die meisten Seiten im ausgewählten Zeitraum editiert haben.';
 $lang['intro_topgroup']        = 'Dies sind die Gruppen der eingeloggten Nutzer die im gewählten Zeitraum die meisten Seiten betrachtet haben. Hinweis: alle Gruppen eines Nutzers werden gezählt.';
 $lang['intro_topgroupedit']    = 'Dies sind die Gruppen der eingeloggten Nutzer die im gewählten Zeitraum die meisten Seiten editiert haben. Hinweis: alle Gruppen eines Nutzers werden gezählt.';
+
+
 $lang['dash_pageviews']        = '<strong>%d</strong> Seitenaufrufe';
 $lang['dash_sessions']         = '<strong>%d</strong> Besuche (Sitzung)';
 $lang['dash_visitors']         = '<strong>%d</strong> Individuelle Besucher';
@@ -83,9 +98,12 @@ $lang['dash_bouncerate']       = '<strong>%.1f%%</strong> Absprünge';
 $lang['dash_timespent']        = '<strong>%.2f</strong> Minuten dauerte ein durchschnittlicher Besuch';
 $lang['dash_avgpages']         = '<strong>%.2f</strong> Seiten wurden während eines durchschnittlichen Besuches angezeigt';
 $lang['dash_newvisitors']      = '<strong>%.1f%%</strong> Neue Besucher';
+
 $lang['dash_mostpopular']      = 'Meistbesuchte Seiten';
 $lang['dash_newincoming']      = 'Top eingegangene, neue Links';
 $lang['dash_topsearch']        = 'Top Suchausdrücke';
+
+
 $lang['graph_edits']           = 'Seiten bearbeitet';
 $lang['graph_creates']         = 'Seiten erstellt';
 $lang['graph_deletions']       = 'Seiten gelöscht';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -3,6 +3,11 @@
  * english language file
  */
 
+
+
+
+
+
 // for admin plugins, the menu prompt to be displayed in the admin menu
 $lang['menu'] = 'Access and Usage Statistics';
 
@@ -17,6 +22,9 @@ $lang['time_last1']  = 'Yesterday';
 $lang['time_last7']  = 'Last 7 Days';
 $lang['time_last30'] = 'Last 30 Days';
 $lang['time_go']     = 'Go';
+$lang['days']                  = 'Days';
+$lang['weeks']                 = 'Weeks';
+$lang['months']                = 'Months';
 
 // the different pages
 $lang['dashboard']             = 'Dashboard';
@@ -50,6 +58,7 @@ $lang['search']                = '(Search)';
 $lang['technology']            = '(Technology)';
 $lang['trafficsum']            = '<strong>%s</strong> requests caused <strong>%s</strong> traffic.';
 
+
 // the intro texts
 $lang['intro_dashboard']             = 'This page gives you a quick overview on what has happened in your wiki during the chosen timeframe.<br />For detailed insights and graphs pick a topic from the Table of Contents.';
 $lang['intro_page']                  = 'These are the wiki pages most viewed in the selected timeframe – your top content.';
@@ -57,6 +66,7 @@ $lang['intro_edits']                 = 'These are the wiki pages most edited in 
 $lang['intro_images']                = 'These are the top most displayed local images in your wiki. The third column shows the total amount of bytes transferred for each item.';
 $lang['intro_downloads']             = 'These are the top most downloaded local media items in your wiki. The third column shows the total amount of bytes transferred for each item.';
 $lang['intro_referer']               = 'Of all <strong>%d</strong> external visits, <strong>%d</strong> (<strong>%.1f%%</strong>) were direct (or bookmarked) accesses, <strong>%d</strong> (<strong>%.1f%%</strong>) came from search engines and <strong>%d</strong> (<strong>%.1f%%</strong>) were referred through links from other pages.<br />These other pages are listed below.';
+
 $lang['intro_newreferer']            = 'The following incoming links where first logged in the selected timeframe and have never been seen before.';
 $lang['intro_outlinks']              = 'These are the most clicked on links to external sites in your wiki.';
 $lang['intro_searchengines']         = 'The following search engines were used by users to find your wiki.';
@@ -104,4 +114,3 @@ $lang['graph_page_count']  = 'Pages';
 $lang['graph_page_size']   = 'Pagessize (MB)';
 $lang['graph_media_count'] = 'Media Items';
 $lang['graph_media_size']  = 'Media Item Size (MB)';
-


### PR DESCRIPTION
If the time interval is now between 8 weeks and 365 days the diagrams a week-sized bins. Below that the bins are day-sized and and for an interval of 366 days and above a bin spans a month.

There was a bug in the SQL Query that summed the data for items grouped by week or month, instead of calculating the average.

I have updated the labels on the graphs, which are now correctly axis-labels. Legend should only be used if there is more then one set of data shown in a graph. (For example if we were to merge two of the graphs).