### PR TITLE
fix sql syntax error if there are no groups to log

### DIFF
--- a/inc/StatisticsLogger.class.php
+++ b/inc/StatisticsLogger.class.php
@@ -81,13 +81,18 @@ class StatisticsLogger {
      * @param array  $groups The groups to log
      */
     public function log_groups($type, $groups) {
-        if(!is_array($groups) || !count($groups)) return;
+        if(!is_array($groups)) {
+            return;
+        }
 
         $tolog = $this->hlp->getConf('loggroups');
         if($tolog) {
             foreach($groups as $pos => $group) {
                 if(!in_array($group, $tolog)) unset($groups[$pos]);
             }
+        }
+        if (!count($groups)) {
+            return;
         }
 
         $type = addslashes($type);


### PR DESCRIPTION
There was an error in `\StatisticsLogger::log_groups` when `$groups` that initially had some entries had all its entries unset. Then the SQL-query would be run without any values and result in a syntax error.