### PR TITLE
Big numbers

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -258,3 +258,6 @@ CREATE TABLE `stats_groups` (
 )
   ENGINE ='MyISAM'
   COLLATE ='utf8_unicode_ci';
+
+-- UPGRADE added 2019-04-10
+ALTER TABLE `stats_history` MODIFY COLUMN `value` BIGINT;

--- a/inc/StatisticsGraph.class.php
+++ b/inc/StatisticsGraph.class.php
@@ -131,7 +131,7 @@ class StatisticsGraph {
         $Chart  = new pChart(600, 200, $Canvas);
 
         $Chart->setFontProperties(dirname(__FILE__) . '/pchart/Fonts/DroidSans.ttf', 8);
-        $Chart->setGraphArea(50, 10, 580, 140);
+        $Chart->setGraphArea(70, 15, 580, 140);
         $Chart->drawScale(
             $DataSet, new ScaleStyle(SCALE_NORMAL, new Color(127)),
             45, 1, false, ceil(count($times) / 12)

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,7 +2,7 @@
 base   statistics
 author Andreas Gohr
 email  andi@splitbrain.org
-date   2017-12-07
+date   2019-04-10
 name   Statistics Plugin
 desc   Gather usage/view statistics
 url    http://www.dokuwiki.org/plugin:statistics


### PR DESCRIPTION
two small adjustments to handle larger numbers in history charts:

1. DB migration from INT to BIGINT for media size
2. more space for Y axis labels
