### PR TITLE
[issue#81] Fix DokuHTTPClient class not found error for DokuWiki 2025…

### DIFF
--- a/inc/StatisticsBrowscap.class.php
+++ b/inc/StatisticsBrowscap.class.php
@@ -24,10 +24,10 @@ class StatisticsBrowscap extends Browscap {
      * @return string
      */
     protected function _getRemoteData($url) {
-        $http = new DokuHTTPClient($url);
-        $file = $http->get($url);
-        if(!$file)
-            throw new Exception('Your server can\'t connect to external resources. Please update the file manually.');
-        return $file;
+    $http = new dokuwiki\HTTP\DokuHTTPClient();
+    $file = $http->get($url);
+    if(!$file)
+        throw new Exception('Your server can\'t connect to external resources. Please update the file manually.');
+    return $file;
     }
 }


### PR DESCRIPTION
…-05-14a

Update StatisticsBrowscap to use the correct namespaced HTTP client class (dokuwiki\HTTP\DokuHTTPClient) instead of the deprecated DokuHTTPClient. This resolves the "Class DokuHTTPClient not found" error that occurs when the statistics plugin attempts to fetch remote browscap data.

- Replace DokuHTTPClient with dokuwiki\HTTP\DokuHTTPClient
- Remove URL parameter from constructor (pass to get() method instead)
- Ensures compatibility with DokuWiki "Librarian" release